### PR TITLE
Initial migration file for django-slack-oauth.

### DIFF
--- a/django_slack_oauth/migrations/0001_initial.py
+++ b/django_slack_oauth/migrations/0001_initial.py
@@ -1,0 +1,25 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+from django.conf import settings
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        migrations.swappable_dependency(settings.AUTH_USER_MODEL)
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='SlackUser',
+            fields=[
+                ('slacker', models.OneToOneField(related_name='slack_user', primary_key=True, serialize=False, to=settings.AUTH_USER_MODEL)),
+                ('access_token', models.CharField(max_length=64, null=True)),
+            ],
+            options={
+                'db_table': 'slack_user',
+            },
+        ),
+    ]


### PR DESCRIPTION
Addresses #2
This change set will allow for users to integrate this library into their project without having to manage their own migrations for the SlackUser model.
