### PR TITLE
Update urls.py.

### DIFF
--- a/django_slack_oauth/urls.py
+++ b/django_slack_oauth/urls.py
@@ -4,6 +4,6 @@ from django.conf.urls import patterns, url
 
 from .views import SlackAuthView
 
-urlpatterns = patterns('',
-                       url('login/', SlackAuthView.as_view(), name='slack_auth'),
-                       )
+urlpatterns = [
+  url('login/', SlackAuthView.as_view(), name='slack_auth'),
+]                

--- a/django_slack_oauth/urls.py
+++ b/django_slack_oauth/urls.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-from django.conf.urls import patterns, url
+from django.conf.urls import url
 
 from .views import SlackAuthView
 

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ setup(
     url='https://github.com/izdi/django-slack-oauth',
     download_url='https://github.com/izdi/django-slack-oauth/tarball/0.4',
     install_requires=[
-        'Django>=1.6.1',
+        'Django>=1.8',
         'requests',
         'jsonfield==1.0.3',
     ],


### PR DESCRIPTION
django.conf.urls.patterns() is deprecated and will be removed in Django 1.10
