### PR TITLE
Increase the max size of SlackUser.access_token to 128 characters

### DIFF
--- a/django_slack_oauth/migrations/0003_slackuser_accesstoken_length.py
+++ b/django_slack_oauth/migrations/0003_slackuser_accesstoken_length.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('django_slack_oauth', '0002_slackuser_extras'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='slackuser',
+            name='access_token',
+            field=models.CharField(max_length=128, null=True),
+        ),
+    ]

--- a/django_slack_oauth/models.py
+++ b/django_slack_oauth/models.py
@@ -12,7 +12,7 @@ __all__ = (
 
 class SlackUser(models.Model):
     slacker = models.OneToOneField(settings.AUTH_USER_MODEL, primary_key=True, related_name='slack_user')
-    access_token = models.CharField(max_length=64, null=True)
+    access_token = models.CharField(max_length=128, null=True)
     extras = JSONField(null=True)
 
     def is_slacked(self):


### PR DESCRIPTION
We've run into some issues storing Slack access tokens in the last couple weeks. It appears that Slack is now serving some access tokens with more than 64 characters (this is sporadic and we can only reproduce with certain accounts). We observed this across 14 accounts over a period of about a week. So far I have been unable to find any authoritative source stating how big the access tokens may get. Increasing the max to 128 characters has fixed the problem as far as our production environment is concerned.
