### PR TITLE
Updates slack_user pipeline

### DIFF
--- a/django_slack_oauth/pipelines.py
+++ b/django_slack_oauth/pipelines.py
@@ -2,6 +2,7 @@
 
 from copy import deepcopy
 
+from django.contrib import messages
 from .models import SlackOAuthRequest, SlackUser
 
 
@@ -37,6 +38,10 @@ def slack_user(request, api_data):
     slacker.access_token = data.pop('access_token')
     slacker.extras = data
     slacker.save()
+
+    messages.add_message(request, messages.SUCCESS, 'Your account has been successfully updated with '
+                                                    'Slack. You can share your messages within your slack '
+                                                    'domain.')
 
     return request, api_data
 


### PR DESCRIPTION
Update includes the `messages.add_message` command to bring the slack_user pipeline to 0.6.1 parity. While technically deprecated it can at least ease future transitions from 0.6.1 to 1.1.0+