### PR TITLE
Fix to be compatible with django 2.x

### DIFF
--- a/django_slack_oauth/__init__.py
+++ b/django_slack_oauth/__init__.py
@@ -1,7 +1,12 @@
 # -*- coding: utf-8 -*-
 
+import django
 from django.conf import settings
-from django.core.urlresolvers import reverse_lazy
+DJANGO_MAJOR_VERSION =  int(django.__version__.split('.')[0])
+if DJANGO_MAJOR_VERSION < 2:
+    from django.core.urlresolvers import reverse_lazy
+else:
+    from django.urls import reverse_lazy
 
 __all__ = (
     'settings',

--- a/django_slack_oauth/migrations/0001_initial.py
+++ b/django_slack_oauth/migrations/0001_initial.py
@@ -15,7 +15,7 @@ class Migration(migrations.Migration):
         migrations.CreateModel(
             name='SlackUser',
             fields=[
-                ('slacker', models.OneToOneField(related_name='slack_user', primary_key=True, serialize=False, to=settings.AUTH_USER_MODEL)),
+                ('slacker', models.OneToOneField(related_name='slack_user', primary_key=True, serialize=False, to=settings.AUTH_USER_MODEL, on_delete=models.CASCADE)),
                 ('access_token', models.CharField(max_length=64, null=True)),
             ],
             options={

--- a/django_slack_oauth/models.py
+++ b/django_slack_oauth/models.py
@@ -15,7 +15,7 @@ __all__ = (
 
 @python_2_unicode_compatible
 class SlackUser(models.Model):
-    slacker = models.OneToOneField(settings.AUTH_USER_MODEL, primary_key=True, related_name='slack_user')
+    slacker = models.OneToOneField(settings.AUTH_USER_MODEL, primary_key=True, related_name='slack_user', on_delete=models.CASCADE)
     access_token = models.CharField(max_length=128, null=True)
     extras = JSONField(null=True)
 
@@ -30,7 +30,7 @@ class SlackUser(models.Model):
 
 
 class SlackOAuthRequest(models.Model):
-    associated_user = models.OneToOneField(settings.AUTH_USER_MODEL, null=True, blank=True)
+    associated_user = models.OneToOneField(settings.AUTH_USER_MODEL, null=True, blank=True, on_delete=models.CASCADE)
     access_token = models.CharField(max_length=128, null=True, blank=True)
     extras = JSONField(null=True, blank=True)
 


### PR DESCRIPTION
Django 2.0 Release Note: https://docs.djangoproject.com/en/2.0/releases/2.0/

* especially: [Features removed in 2.0](https://docs.djangoproject.com/en/2.0/releases/2.0/#features-removed-in-2-0)

1. django.core.urlresolvers model move to django.urls
1. on_delete argument for ForeignKey and OneToOneField is required