### PR TITLE
use the session to store the random state

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,13 +167,4 @@ SLACK_OAUTH_ACCESS_URL = 'https://slack.com/api/oauth.access'
 
 ### Forgery Attacks
 
-To avoid forgery attacks we pass the `state` parameter in the initial authorization request. This state is stored in cache. For production environments, it's highly recommended to avoid using `LocMemCache`, and set up your cache backend using `redis` or `MemcachedCache`. For example:
-
-```python
-CACHES = {
-    'default': {
-        'BACKEND': 'django.core.cache.backends.memcached.MemcachedCache',
-        'LOCATION': '127.0.0.1:11211',
-    }
-}
-```
+To avoid forgery attacks we pass the `state` parameter in the initial authorization request. This state is stored in the session, which requires the [session middleware to be enabled](https://docs.djangoproject.com/en/2.1/topics/http/sessions/#enabling-sessions) (on by default).


### PR DESCRIPTION
When the user isn't logged in `self.request.user` returns an `AnonymousUser` which makes the `cache_key` always be `slack:AnonymousUser`.

If two people try to login at the same time the first user will get a `StateMismatch` error as the cache key has been overwritten by the second user.

This PR switches to storing the random `state` in the session instead so they don't clash.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/izdi/django-slack-oauth/24)
<!-- Reviewable:end -->
